### PR TITLE
Various fixes for nightly; adjust enums

### DIFF
--- a/src/al.rs
+++ b/src/al.rs
@@ -252,12 +252,12 @@ pub fn set_speed_of_sound(value: ALfloat) {
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum DistanceModel {
-    InverseDistance             = ffi::INVERSE_DISTANCE,
-    InverseDistanceClamped      = ffi::INVERSE_DISTANCE_CLAMPED,
-    LinearDistance              = ffi::LINEAR_DISTANCE,
-    LinearDistanceClamped       = ffi::LINEAR_DISTANCE_CLAMPED,
-    ExponentDistance            = ffi::EXPONENT_DISTANCE,
-    ExponentDistanceClamped     = ffi::EXPONENT_DISTANCE_CLAMPED
+    Inverse             = ffi::INVERSE_DISTANCE,
+    InverseClamped      = ffi::INVERSE_DISTANCE_CLAMPED,
+    Linear              = ffi::LINEAR_DISTANCE,
+    LinearClamped       = ffi::LINEAR_DISTANCE_CLAMPED,
+    Exponent            = ffi::EXPONENT_DISTANCE,
+    ExponentClamped     = ffi::EXPONENT_DISTANCE_CLAMPED
 }
 
 pub fn get_distance_model() -> Option<DistanceModel> {
@@ -778,10 +778,10 @@ pub fn delete_buffers(buffers: Vec<Buffer>) {
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Format {
-    FormatMono8         = ffi::FORMAT_MONO8     as int,
-    FormatMono16        = ffi::FORMAT_MONO16    as int,
-    FormatStereo8       = ffi::FORMAT_STEREO8   as int,
-    FormatStereo16      = ffi::FORMAT_STEREO16  as int,
+    Mono8         = ffi::FORMAT_MONO8     as int,
+    Mono16        = ffi::FORMAT_MONO16    as int,
+    Stereo8       = ffi::FORMAT_STEREO8   as int,
+    Stereo16      = ffi::FORMAT_STEREO16  as int,
 }
 
 impl Buffer {

--- a/src/al.rs
+++ b/src/al.rs
@@ -249,7 +249,7 @@ pub fn set_speed_of_sound(value: ALfloat) {
     unsafe { ffi::alSpeedOfSound(value); }
 }
 
-#[deriving(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum DistanceModel {
     InverseDistance             = ffi::INVERSE_DISTANCE,
@@ -279,7 +279,7 @@ pub fn set_distance_model(value: Option<DistanceModel>) {
 }
 
 /// An OpenAL error code
-#[deriving(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Error {
     /// A bad name (ID) was passed to an OpenAL function.
     InvalidName,
@@ -339,44 +339,44 @@ pub mod listener {
     }
 
     // The position of the listener.
-    pub fn get_position() -> [ALfloat, ..3] {
+    pub fn get_position() -> [ALfloat; 3] {
         unsafe {
-            let mut values = [0.0, ..3];
+            let mut values = [0.0; 3];
             ffi::alGetListenerfv(ffi::GAIN, &mut values[0]);
             values
         }
     }
 
     /// Set the position of the listener.
-    pub fn set_position(values: [ALfloat, ..3]) {
+    pub fn set_position(values: [ALfloat; 3]) {
         unsafe { ffi::alListenerfv(ffi::POSITION, &values[0]); }
     }
 
     // The velocity vector.
-    pub fn get_velocity() -> [ALfloat, ..3] {
+    pub fn get_velocity() -> [ALfloat; 3] {
         unsafe {
-            let mut values = [0.0, ..3];
+            let mut values = [0.0; 3];
             ffi::alGetListenerfv(ffi::VELOCITY, &mut values[0]);
             values
         }
     }
 
     /// Set the velocity vector.
-    pub fn set_velocity(values: [ALfloat, ..3]) {
+    pub fn set_velocity(values: [ALfloat; 3]) {
         unsafe { ffi::alListenerfv(ffi::VELOCITY, &values[0]); }
     }
 
     // The orientation of the listener, expressed as 'at' and 'up' vectors.
-    pub fn get_orientation() -> ([ALfloat, ..3], [ALfloat, ..3]) {
+    pub fn get_orientation() -> ([ALfloat; 3], [ALfloat; 3]) {
         unsafe {
-            let mut values = ([0.0, ..3], [0.0, ..3]);
+            let mut values = ([0.0; 3], [0.0; 3]);
             ffi::alGetListenerfv(ffi::ORIENTATION, mem::transmute(&mut values));
             values
         }
     }
 
     /// Set the orientation of the listener.
-    pub fn set_orientation(at: [ALfloat, ..3], up: [ALfloat, ..3]) {
+    pub fn set_orientation(at: [ALfloat; 3], up: [ALfloat; 3]) {
         unsafe {
             let values = (at, up);
             ffi::alListenerfv(ffi::ORIENTATION, mem::transmute(&values));
@@ -410,7 +410,7 @@ pub fn delete_sources(sources: Vec<Source>) {
     // unsafe { ffi::alDeleteSources(sources.len() as ALsizei, &sources[0].id); }
 }
 
-#[deriving(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum SourceType {
     Static          = ffi::STATIC,
@@ -420,7 +420,7 @@ pub enum SourceType {
 
 macro_rules! get_source{
     ($self_:ident, fv, $param:expr, $n:expr) => ({
-        let mut values = [0.0, ..$n];
+        let mut values = [0.0; $n];
         ffi::alGetSourcef($self_.id, $param, &mut values[0]);
         values
     });
@@ -626,32 +626,32 @@ impl Source {
     }
 
     // The position of the source.
-    pub fn get_position(&self) -> [ALfloat, ..3] {
+    pub fn get_position(&self) -> [ALfloat; 3] {
         unsafe { get_source!(self, fv, ffi::POSITION, 3) }
     }
 
     /// Set the position of the source.
-    pub fn set_position(&self, values: [ALfloat, ..3]) {
+    pub fn set_position(&self, values: [ALfloat; 3]) {
         unsafe { ffi::alSourcefv(self.id, ffi::POSITION, &values[0]); }
     }
 
     // The velocity vector of the source.
-    pub fn get_velocity(&self) -> [ALfloat, ..3] {
+    pub fn get_velocity(&self) -> [ALfloat; 3] {
         unsafe { get_source!(self, fv, ffi::VELOCITY, 3) }
     }
 
     /// Set the velocity vector of the source.
-    pub fn set_velocity(&self, values: [ALfloat, ..3]) {
+    pub fn set_velocity(&self, values: [ALfloat; 3]) {
         unsafe { ffi::alSourcefv(self.id, ffi::VELOCITY, &values[0]); }
     }
 
     // The direction vector of the source.
-    pub fn get_direction(&self) -> [ALfloat, ..3] {
+    pub fn get_direction(&self) -> [ALfloat; 3] {
         unsafe { get_source!(self, fv, ffi::DIRECTION, 3) }
     }
 
     /// Set the direction vector of the source.
-    pub fn set_direction(&self, values: [ALfloat, ..3]) {
+    pub fn set_direction(&self, values: [ALfloat; 3]) {
         unsafe { ffi::alSourcefv(self.id, ffi::DIRECTION, &values[0]); }
     }
 
@@ -776,7 +776,7 @@ pub fn delete_buffers(buffers: Vec<Buffer>) {
     // unsafe { ffi::alDeleteBuffers(buffers.len() as ALsizei, &buffers[0].id); }
 }
 
-#[deriving(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Format {
     FormatMono8         = ffi::FORMAT_MONO8     as int,
     FormatMono16        = ffi::FORMAT_MONO16    as int,

--- a/src/alc.rs
+++ b/src/alc.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use std::ptr;
+use std::c_str::ToCStr;
 
 use self::types::*;
 

--- a/tests/sin.rs
+++ b/tests/sin.rs
@@ -5,13 +5,14 @@ use std::f64::consts::PI;
 use std::num::FloatMath;
 use std::io::timer::sleep;
 use std::time::duration::Duration;
+use std::iter;
 use openal::al;
 use openal::alc;
 
 #[test]
 fn play_sin() {
   let device = alc::Device::open(None).expect("Could not open device");
-  let ctx = device.create_context([]).expect("Could not create context");
+  let ctx = device.create_context(&[]).expect("Could not create context");
   ctx.make_current();
 
   let buffer = al::Buffer::gen();
@@ -22,12 +23,12 @@ fn play_sin() {
   let duration = 3.0;
   let num_samples = (sample_freq * duration) as uint;
 
-  let samples: Vec<i16> = Vec::from_fn(num_samples, |x| {
+  let samples: Vec<i16> = iter::range(0, num_samples).map(|x| {
     let t = x as f64;
     ((tone_freq * t * 2.0 * PI / sample_freq).sin() * (i16::MAX - 1) as f64) as i16
-  });
+  }).collect();
 
-  unsafe { buffer.buffer_data(al::FormatMono16, samples.as_slice(), sample_freq as al::ALsizei) };
+  unsafe { buffer.buffer_data(al::Format::Mono16, samples.as_slice(), sample_freq as al::ALsizei) };
 
   source.queue_buffer(&buffer);
   source.play();


### PR DESCRIPTION
This adds the new array syntax and changes deriving to derive.
The test program is brought up to date, and some of the enums are also adjusted to remove stutter. This is a breaking change, naturally.