### PR TITLE
Nightly fixes; remove feature gates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ authors = [ "" ]
 
 [lib]
 name = "openal"
+
+[dependencies]
+libc = "*"

--- a/src/al.rs
+++ b/src/al.rs
@@ -13,10 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::ToOwned;
 use std::fmt;
 use std::mem;
 use std::str;
-use std::ffi::c_str_to_bytes;
+use std::ffi::CStr;
 use libc;
 
 pub use self::types::*;
@@ -213,19 +214,19 @@ pub mod ffi {
 }
 
 pub fn get_vendor() -> String {
-    unsafe { String::from_str(str::from_utf8(c_str_to_bytes(&(ffi::alGetString(ffi::VENDOR) as *const libc::c_char))).unwrap()) }
+    unsafe { str::from_utf8(CStr::from_ptr(ffi::alGetString(ffi::VENDOR) as *const libc::c_char).to_bytes()).unwrap().to_owned() }
 }
 
 pub fn get_version() -> String {
-    unsafe { String::from_str(str::from_utf8(c_str_to_bytes(&(ffi::alGetString(ffi::VERSION) as *const libc::c_char))).unwrap()) }
+    unsafe { str::from_utf8(CStr::from_ptr(ffi::alGetString(ffi::VERSION) as *const libc::c_char).to_bytes()).unwrap().to_owned() }
 }
 
 pub fn get_renderer() -> String {
-    unsafe { String::from_str(str::from_utf8(c_str_to_bytes(&(ffi::alGetString(ffi::RENDERER) as *const libc::c_char))).unwrap()) }
+    unsafe { str::from_utf8(CStr::from_ptr(ffi::alGetString(ffi::RENDERER) as *const libc::c_char).to_bytes()).unwrap().to_owned() }
 }
 
 pub fn get_extensions() -> String {
-    unsafe { String::from_str(str::from_utf8(c_str_to_bytes(&(ffi::alGetString(ffi::EXTENSIONS) as *const libc::c_char))).unwrap()) }
+    unsafe { str::from_utf8(CStr::from_ptr(ffi::alGetString(ffi::EXTENSIONS) as *const libc::c_char).to_bytes()).unwrap().to_owned() }
 }
 
 pub fn get_doppler_factor() -> ALfloat {

--- a/src/openal.rs
+++ b/src/openal.rs
@@ -6,8 +6,6 @@
 
 #![crate_type = "lib"]
 
-#![feature(libc, collections, std_misc)]
-
 extern crate libc;
 
 pub mod al;

--- a/tests/sin.rs
+++ b/tests/sin.rs
@@ -1,12 +1,9 @@
-#![feature(std_misc)]
 
 extern crate openal;
 
 use std::i16;
 use std::f64::consts::PI;
-use std::num::Float;
-use std::old_io::timer::sleep;
-use std::time::duration::Duration;
+use std::thread::sleep_ms;
 use openal::al;
 use openal::alc;
 
@@ -34,7 +31,7 @@ fn play_sin() {
   source.queue_buffer(&buffer);
   source.play();
 
-  sleep(Duration::milliseconds((duration * 1000.0) as i64));
+  sleep_ms((duration * 1000.0) as u32);
 
   ctx.destroy();
   device.close().ok().expect("Unable to close device");


### PR DESCRIPTION
This fixes the use of a few deprecated methods and removes all gated functionality in preparation for beta1 and crates.io.

On a related note, I saw over on the cgmath board that you've got a lot on your plate. I'd be happy to assume maintenance of openal-rs if you'd rather focus on your other projects; just let me know.